### PR TITLE
Refactor activity schema, clean up components

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -105,9 +105,6 @@ export const activityTable = sqliteTable(
     type: text('type', { enum: VALID_ACTIVITY_TYPES }).notNull(),
     externalId: text('external_id').notNull(),
     timestamp: integer('timestamp').notNull(),
-    title: text('title').notNull(),
-    url: text('url'),
-    thumbnailUrl: text('thumbnail_url'),
     isPrivate: integer('is_private', { mode: 'boolean' }).notNull().default(false),
     // Threading support: true for non-Bluesky and Bluesky thread roots
     isThreadRoot: integer('is_thread_root', { mode: 'boolean' }).notNull().default(true),
@@ -142,6 +139,8 @@ export const activityPlexTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    thumbnailUrl: text('thumbnail_url'),
     mediaType: text('media_type', { enum: VALID_PLEX_MEDIA_TYPES }).notNull(),
     imdbId: text('imdb_id'),
     imdbUrl: text('imdb_url'),
@@ -178,6 +177,8 @@ export const activityGithubTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    url: text('url'),
     eventType: text('event_type', { enum: VALID_GITHUB_EVENT_TYPES }).notNull(),
     repo: text('repo').notNull(),
     ref: text('ref'),
@@ -237,6 +238,7 @@ export const activityBlueskyTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
     authorDid: text('author_did').references(() => blueskyAuthorsTable.did),
     postText: text('post_text').notNull(),
     isReply: integer('is_reply', { mode: 'boolean' }).notNull().default(false),
@@ -266,6 +268,8 @@ export const activityRedditTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    url: text('url'),
     subreddit: text('subreddit').notNull(),
     itemType: text('item_type', { enum: VALID_REDDIT_ITEM_TYPES }).notNull(),
     body: text('body'),
@@ -291,6 +295,8 @@ export const activityHackernewsTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    url: text('url'),
     itemType: text('item_type', { enum: VALID_HN_ITEM_TYPES }).notNull(),
     body: text('body'),
     hnScore: integer('hn_score'),
@@ -314,6 +320,8 @@ export const activityBggTable = sqliteTable(
     activityId: integer('activity_id')
       .notNull()
       .references(() => activityTable.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    thumbnailUrl: text('thumbnail_url'),
     gameId: integer('game_id').notNull(), // BGG game ID
     playDate: text('play_date'), // YYYY-MM-DD format from BGG
     location: text('location'),

--- a/src/drizzle/0015_activity-schema-refactor.sql
+++ b/src/drizzle/0015_activity-schema-refactor.sql
@@ -1,0 +1,34 @@
+ALTER TABLE `activity_bgg` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_bgg` ADD `thumbnail_url` text;--> statement-breakpoint
+ALTER TABLE `activity_bluesky` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_github` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_github` ADD `url` text;--> statement-breakpoint
+ALTER TABLE `activity_hackernews` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_hackernews` ADD `url` text;--> statement-breakpoint
+ALTER TABLE `activity_plex` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_plex` ADD `thumbnail_url` text;--> statement-breakpoint
+ALTER TABLE `activity_reddit` ADD `title` text;--> statement-breakpoint
+ALTER TABLE `activity_reddit` ADD `url` text;--> statement-breakpoint
+
+-- Copy data from activity to subtables
+UPDATE activity_plex SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_plex.activity_id),
+  thumbnail_url = (SELECT thumbnail_url FROM activity WHERE activity.id = activity_plex.activity_id);--> statement-breakpoint
+UPDATE activity_github SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_github.activity_id),
+  url = (SELECT url FROM activity WHERE activity.id = activity_github.activity_id);--> statement-breakpoint
+UPDATE activity_bluesky SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_bluesky.activity_id);--> statement-breakpoint
+UPDATE activity_reddit SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_reddit.activity_id),
+  url = (SELECT url FROM activity WHERE activity.id = activity_reddit.activity_id);--> statement-breakpoint
+UPDATE activity_hackernews SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_hackernews.activity_id),
+  url = (SELECT url FROM activity WHERE activity.id = activity_hackernews.activity_id);--> statement-breakpoint
+UPDATE activity_bgg SET
+  title = (SELECT title FROM activity WHERE activity.id = activity_bgg.activity_id),
+  thumbnail_url = (SELECT thumbnail_url FROM activity WHERE activity.id = activity_bgg.activity_id);--> statement-breakpoint
+
+ALTER TABLE `activity` DROP COLUMN `title`;--> statement-breakpoint
+ALTER TABLE `activity` DROP COLUMN `url`;--> statement-breakpoint
+ALTER TABLE `activity` DROP COLUMN `thumbnail_url`;

--- a/src/drizzle/meta/0015_snapshot.json
+++ b/src/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1097 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "42211eb5-61f5-465e-a6ef-7fc25e8917cc",
+  "prevId": "8cc4ee69-8e6e-4385-b4d5-40b4c6185396",
+  "tables": {
+    "activity_bgg": {
+      "name": "activity_bgg",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "play_date": {
+          "name": "play_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_players": {
+          "name": "num_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete": {
+          "name": "incomplete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_bgg_activity_id": {
+          "name": "idx_bgg_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_bgg_activity_id_activity_id_fk": {
+          "name": "activity_bgg_activity_id_activity_id_fk",
+          "tableFrom": "activity_bgg",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_bluesky": {
+      "name": "activity_bluesky",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_text": {
+          "name": "post_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_reply": {
+          "name": "is_reply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reply_to_uri": {
+          "name": "reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "facets": {
+          "name": "facets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_posts": {
+          "name": "thread_posts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_bluesky_activity_id": {
+          "name": "idx_bluesky_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        },
+        "idx_bluesky_root_uri": {
+          "name": "idx_bluesky_root_uri",
+          "columns": ["root_uri"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_bluesky_activity_id_activity_id_fk": {
+          "name": "activity_bluesky_activity_id_activity_id_fk",
+          "tableFrom": "activity_bluesky",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_bluesky_author_did_bluesky_authors_did_fk": {
+          "name": "activity_bluesky_author_did_bluesky_authors_did_fk",
+          "tableFrom": "activity_bluesky",
+          "tableTo": "bluesky_authors",
+          "columnsFrom": ["author_did"],
+          "columnsTo": ["did"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_github": {
+      "name": "activity_github",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_message": {
+          "name": "commit_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_github_activity_id": {
+          "name": "idx_github_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_github_activity_id_activity_id_fk": {
+          "name": "activity_github_activity_id_activity_id_fk",
+          "tableFrom": "activity_github",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_hackernews": {
+      "name": "activity_hackernews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hn_score": {
+          "name": "hn_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_id": {
+          "name": "root_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_hackernews_activity_id": {
+          "name": "idx_hackernews_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_hackernews_activity_id_activity_id_fk": {
+          "name": "activity_hackernews_activity_id_activity_id_fk",
+          "tableFrom": "activity_hackernews",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_plex": {
+      "name": "activity_plex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imdb_url": {
+          "name": "imdb_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "director": {
+          "name": "director",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_plex_activity_id": {
+          "name": "idx_plex_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_plex_activity_id_activity_id_fk": {
+          "name": "activity_plex_activity_id_activity_id_fk",
+          "tableFrom": "activity_plex",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_reddit": {
+      "name": "activity_reddit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reddit_activity_id": {
+          "name": "idx_reddit_activity_id",
+          "columns": ["activity_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_reddit_activity_id_activity_id_fk": {
+          "name": "activity_reddit_activity_id_activity_id_fk",
+          "tableFrom": "activity_reddit",
+          "tableTo": "activity",
+          "columnsFrom": ["activity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity": {
+      "name": "activity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_thread_root": {
+          "name": "is_thread_root",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "thread_latest_timestamp": {
+          "name": "thread_latest_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_activity_type": {
+          "name": "idx_activity_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_activity_timestamp": {
+          "name": "idx_activity_timestamp",
+          "columns": ["timestamp"],
+          "isUnique": false
+        },
+        "idx_activity_type_external_id": {
+          "name": "idx_activity_type_external_id",
+          "columns": ["type", "external_id"],
+          "isUnique": true
+        },
+        "idx_activity_thread_feed": {
+          "name": "idx_activity_thread_feed",
+          "columns": ["is_thread_root", "thread_latest_timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bluesky_authors": {
+      "name": "bluesky_authors",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_upload_date": {
+          "name": "original_upload_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vision_label": {
+          "name": "vision_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dominant_colors": {
+          "name": "dominant_colors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dominant_color": {
+          "name": "dominant_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focus_color": {
+          "name": "focus_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_type_category": {
+          "name": "file_type_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "files_fileId_unique": {
+          "name": "files_fileId_unique",
+          "columns": ["fileId"],
+          "isUnique": true
+        },
+        "idx_file_id": {
+          "name": "idx_file_id",
+          "columns": ["fileId"],
+          "isUnique": false
+        },
+        "idx_original_upload_date": {
+          "name": "idx_original_upload_date",
+          "columns": ["original_upload_date"],
+          "isUnique": false
+        },
+        "idx_file_type_category": {
+          "name": "idx_file_type_category",
+          "columns": ["file_type_category"],
+          "isUnique": false
+        },
+        "idx_is_hidden": {
+          "name": "idx_is_hidden",
+          "columns": ["is_hidden"],
+          "isUnique": false
+        },
+        "idx_is_favorite": {
+          "name": "idx_is_favorite",
+          "columns": ["is_favorite"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gallery": {
+      "name": "gallery",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gallery_name_unique": {
+          "name": "gallery_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gallery_to_files": {
+      "name": "gallery_to_files",
+      "columns": {
+        "gallery_id": {
+          "name": "gallery_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gallery_to_files_gallery_id_gallery_id_fk": {
+          "name": "gallery_to_files_gallery_id_gallery_id_fk",
+          "tableFrom": "gallery_to_files",
+          "tableTo": "gallery",
+          "columnsFrom": ["gallery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gallery_to_files_file_id_files_id_fk": {
+          "name": "gallery_to_files_file_id_files_id_fk",
+          "tableFrom": "gallery_to_files",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gallery_to_files_gallery_id_file_id_pk": {
+          "columns": ["gallery_id", "file_id"],
+          "name": "gallery_to_files_gallery_id_file_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "links": {
+      "name": "links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "og_cache": {
+      "name": "og_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "og_cache_url_unique": {
+          "name": "og_cache_url_unique",
+          "columns": ["url"],
+          "isUnique": true
+        },
+        "idx_og_cache_url": {
+          "name": "idx_og_cache_url",
+          "columns": ["url"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780671987699,
       "tag": "0014_activity-tables",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1780754554822,
+      "tag": "0015_activity-schema-refactor",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/ActivityItem/ActivityItem.svelte
+++ b/src/lib/components/ActivityItem/ActivityItem.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import { mode } from 'mode-watcher';
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    type: string;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+    children: Snippet;
+  }
+
+  let { type, timestamp, isPrivate, isAdmin, onHide, children }: Props = $props();
+
+  let iconColor = $derived(mode.current === 'light' ? 'black' : 'white');
+
+  function getTypeIcon(activityType: string, color: string): string {
+    const base = 'https://cdn.simpleicons.org';
+    switch (activityType) {
+      case 'plex':
+        return `${base}/plex/${color}`;
+      case 'github':
+        return `${base}/github/${color}`;
+      case 'bluesky':
+        return `${base}/bluesky/${color}`;
+      case 'reddit':
+        return `${base}/reddit/${color}`;
+      case 'hackernews':
+        return `${base}/ycombinator/${color}`;
+      case 'bgg':
+        return `${base}/boardgamegeek/${color}`;
+      default:
+        return `${base}/github/${color}`;
+    }
+  }
+
+  function formatTimestamp(ts: number): string {
+    const date = new Date(ts * 1000);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 7) {
+      return date.toLocaleDateString();
+    } else if (days > 0) {
+      return `${days}d ago`;
+    } else if (hours > 0) {
+      return `${hours}h ago`;
+    } else if (minutes > 0) {
+      return `${minutes}m ago`;
+    } else {
+      return 'just now';
+    }
+  }
+
+  function getTypeLabel(activityType: string): string {
+    switch (activityType) {
+      case 'hackernews':
+        return 'Hacker News';
+      case 'bgg':
+        return 'BGG';
+      default:
+        return activityType.charAt(0).toUpperCase() + activityType.slice(1);
+    }
+  }
+</script>
+
+<div class="activityItem activityItem--{type}">
+  <div class="activityItem__header">
+    <img src={getTypeIcon(type, iconColor)} alt="" class="activityItem__icon" />
+    <span class="activityItem__type">{getTypeLabel(type)}</span>
+    <span class="activityItem__time">{formatTimestamp(timestamp)}</span>
+    {#if isPrivate && isAdmin}
+      <span class="activityItem__private">private</span>
+    {/if}
+    {#if isAdmin}
+      <button class="activityItem__hide" onclick={onHide}>&times;</button>
+    {/if}
+  </div>
+  <div class="activityItem__body">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .activityItem {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .activityItem__header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--subtle);
+  }
+
+  .activityItem__icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .activityItem__type {
+    text-transform: capitalize;
+  }
+
+  .activityItem__time {
+    color: var(--subtle);
+  }
+
+  .activityItem__private {
+    font-size: 0.75rem;
+  }
+
+  .activityItem__hide {
+    opacity: 0;
+    background: none;
+    border: none;
+    color: var(--subtle);
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    line-height: 1;
+    transition: opacity 0.15s;
+  }
+
+  .activityItem__hide:hover {
+    color: red;
+  }
+
+  .activityItem:hover .activityItem__hide {
+    opacity: 1;
+  }
+
+  .activityItem__body {
+    margin-left: 1.75rem;
+  }
+
+  /* Type-specific modifiers */
+  .activityItem--github,
+  .activityItem--hackernews,
+  .activityItem--reddit,
+  .activityItem--bgg {
+    margin-bottom: 1rem;
+  }
+
+  .activityItem--bluesky .activityItem__body {
+    margin-left: 1rem;
+  }
+</style>

--- a/src/lib/components/ActivityItem/ActivityItem.svelte
+++ b/src/lib/components/ActivityItem/ActivityItem.svelte
@@ -18,8 +18,6 @@
   function getTypeIcon(activityType: string, color: string): string {
     const base = 'https://cdn.simpleicons.org';
     switch (activityType) {
-      case 'plex':
-        return `${base}/plex/${color}`;
       case 'github':
         return `${base}/github/${color}`;
       case 'bluesky':
@@ -71,7 +69,14 @@
 
 <div class="activityItem activityItem--{type}">
   <div class="activityItem__header">
-    <img src={getTypeIcon(type, iconColor)} alt="" class="activityItem__icon" />
+    {#if type === 'plex'}
+      <svg class="activityItem__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor">
+        <circle cx="8" cy="8" r="7" stroke-width="1.5" />
+        <path d="M6.5 5L10.5 8L6.5 11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    {:else}
+      <img src={getTypeIcon(type, iconColor)} alt="" class="activityItem__icon" />
+    {/if}
     <span class="activityItem__type">{getTypeLabel(type)}</span>
     <span class="activityItem__time">{formatTimestamp(timestamp)}</span>
     {#if isPrivate && isAdmin}
@@ -106,6 +111,7 @@
   .activityItem__icon {
     width: 1rem;
     height: 1rem;
+    color: var(--fg);
   }
 
   .activityItem__type {

--- a/src/lib/components/ActivityItem/ActivityItemBgg.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemBgg.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import type { SelectActivityBgg } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+
+  interface Props {
+    details: SelectActivityBgg;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+  }
+
+  let { details, timestamp, isPrivate, isAdmin, onHide }: Props = $props();
+
+  let bggUrl = $derived(`https://boardgamegeek.com/boardgame/${details.gameId}`);
+</script>
+
+<ActivityItem type="bgg" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <div class="bggBody">
+    {#if details.thumbnailUrl}
+      <a href={bggUrl} target="_blank" rel="noopener noreferrer">
+        <img src={details.thumbnailUrl} alt="" class="bggBody__thumbnail" />
+      </a>
+    {/if}
+    <div class="bggBody__content">
+      <a href={bggUrl} target="_blank" rel="noopener noreferrer" class="bggBody__title">
+        {details.title}
+      </a>
+      <div class="bggBody__meta">
+        {#if details.playDate}
+          <span>Played {details.playDate}</span>
+        {/if}
+        {#if details.numPlayers}
+          <span>{details.numPlayers} player{details.numPlayers !== 1 ? 's' : ''}</span>
+        {/if}
+        {#if details.location}
+          <span>at {details.location}</span>
+        {/if}
+      </div>
+      {#if details.comments}
+        <div class="bggBody__comments">{details.comments}</div>
+      {/if}
+    </div>
+  </div>
+</ActivityItem>
+
+<style>
+  .bggBody {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .bggBody__thumbnail {
+    width: 4rem;
+    height: 4rem;
+    object-fit: cover;
+    border-radius: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  .bggBody__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .bggBody__title {
+    font-weight: 600;
+    line-height: 1.4;
+    text-decoration: none;
+    color: var(--fg);
+  }
+
+  .bggBody__title:hover {
+    text-decoration: underline;
+  }
+
+  .bggBody__meta {
+    color: var(--subtle);
+    font-size: 0.875rem;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .bggBody__meta span:not(:last-child)::after {
+    content: ' \00b7';
+    margin-left: 0.5rem;
+  }
+
+  .bggBody__comments {
+    line-height: 1.6;
+    color: var(--fg);
+    font-size: 0.9375rem;
+    white-space: pre-line;
+    margin-top: 0.25rem;
+  }
+
+  @media (max-width: 768px) {
+    .bggBody {
+      display: block;
+    }
+
+    .bggBody__thumbnail {
+      float: left;
+      margin-right: 1rem;
+      margin-bottom: 0.5rem;
+    }
+  }
+</style>

--- a/src/lib/components/ActivityItem/ActivityItemBluesky.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemBluesky.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { BlueskyThreadPost, SelectBlueskyAuthor } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+  import BlueskyThread from '$lib/components/BlueskyThread/BlueskyThread.svelte';
+
+  interface Props {
+    externalId: string;
+    thread: BlueskyThreadPost[];
+    authors: Map<string, SelectBlueskyAuthor>;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+  }
+
+  let { externalId, thread, authors, timestamp, isPrivate, isAdmin, onHide }: Props = $props();
+</script>
+
+<ActivityItem type="bluesky" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <BlueskyThread {thread} {authors} currentUri={externalId} />
+</ActivityItem>

--- a/src/lib/components/ActivityItem/ActivityItemGithub.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemGithub.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import type { SelectActivityGithub } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+  import { marked } from 'marked';
+  import DOMPurify from 'isomorphic-dompurify';
+
+  const renderer = new marked.Renderer();
+  renderer.image = ({ href, title, text }) => {
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer"><img src="${href}" alt="${text}"${titleAttr}></a>`;
+  };
+  marked.use({ renderer });
+
+  interface Props {
+    details: SelectActivityGithub;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+  }
+
+  let { details, timestamp, isPrivate, isAdmin, onHide }: Props = $props();
+
+  let isComment = $derived(details.eventType === 'issue_comment');
+</script>
+
+<ActivityItem type="github" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <a href="https://github.com/{details.repo}" class="githubBody__repo" target="_blank" rel="noopener noreferrer">
+    {details.repo}
+  </a>
+  <a href={details.url} class="githubBody__title" target="_blank" rel="noopener noreferrer">
+    {details.title}
+  </a>
+  {#if details.commitMessage && (details.eventType === 'issue_comment' || details.eventType === 'pr_opened')}
+    <div class="githubBody__reply" class:githubBody__reply--visible={isComment}>
+      <span class="githubBody__replyArrow">&curarr;</span>
+      <div class="githubBody__message">
+        {@html DOMPurify.sanitize(marked(details.commitMessage) as string)}
+      </div>
+    </div>
+  {/if}
+</ActivityItem>
+
+<style>
+  .githubBody__repo {
+    display: block;
+    font-family: 'BerkeleyMono', monospace;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg);
+    text-decoration: none;
+  }
+
+  .githubBody__repo:hover {
+    text-decoration: underline;
+  }
+
+  .githubBody__title {
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--subtle);
+    text-decoration: none;
+  }
+
+  .githubBody__title:hover {
+    text-decoration: underline;
+  }
+
+  .githubBody__reply {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .githubBody__replyArrow {
+    display: none;
+    color: var(--subtle);
+    font-size: 1rem;
+    line-height: 1.6;
+    flex-shrink: 0;
+  }
+
+  .githubBody__reply--visible .githubBody__replyArrow {
+    display: block;
+  }
+
+  .githubBody__reply--visible .githubBody__message {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .githubBody__message {
+    line-height: 1.6;
+  }
+
+  .githubBody__message :global(p) {
+    margin: 0.5rem 0;
+  }
+
+  .githubBody__message :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  .githubBody__message :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .githubBody__message :global(a) {
+    color: var(--fg);
+    text-decoration: underline;
+  }
+
+  .githubBody__message :global(code) {
+    font-family: 'BerkeleyMono', monospace;
+    background: color-mix(in srgb, var(--fg) 10%, transparent);
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.9em;
+  }
+
+  .githubBody__message :global(pre) {
+    background: color-mix(in srgb, var(--fg) 10%, transparent);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    margin: 0.5rem 0;
+  }
+
+  .githubBody__message :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+
+  .githubBody__message :global(img) {
+    max-width: 100%;
+    height: auto;
+  }
+</style>

--- a/src/lib/components/ActivityItem/ActivityItemGithub.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemGithub.svelte
@@ -33,7 +33,7 @@
   </a>
   {#if details.commitMessage && (details.eventType === 'issue_comment' || details.eventType === 'pr_opened')}
     <div class="githubBody__reply" class:githubBody__reply--visible={isComment}>
-      <span class="githubBody__replyArrow">&curarr;</span>
+      <span class="githubBody__replyArrow">⤷</span>
       <div class="githubBody__message">
         {@html DOMPurify.sanitize(marked(details.commitMessage) as string)}
       </div>

--- a/src/lib/components/ActivityItem/ActivityItemHackernews.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemHackernews.svelte
@@ -41,7 +41,7 @@
   </div>
   {#if details.body}
     <div class="hnBody__reply" class:hnBody__reply--visible={isComment}>
-      <span class="hnBody__replyArrow">&curarr;</span>
+      <span class="hnBody__replyArrow">⤷</span>
       <div class="hnBody__text">{@html DOMPurify.sanitize(details.body)}</div>
     </div>
   {/if}

--- a/src/lib/components/ActivityItem/ActivityItemHackernews.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemHackernews.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import type { SelectActivityHackernews } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+  import DOMPurify from 'isomorphic-dompurify';
+
+  interface Props {
+    details: SelectActivityHackernews;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+  }
+
+  let { details, timestamp, isPrivate, isAdmin, onHide }: Props = $props();
+
+  const hnTypeMap: Record<string, string> = {
+    story: 'Post',
+    comment: 'Comment',
+    ask: 'Ask HN',
+    show: 'Show HN'
+  };
+
+  let hnType = $derived(details.itemType ? hnTypeMap[details.itemType] || 'Post' : 'Post');
+  let hnTitle = $derived((details.title || '').replace(/^Comment on:\s*/i, ''));
+  let isComment = $derived(details.itemType === 'comment');
+</script>
+
+<ActivityItem type="hackernews" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <div class="hnBody__row">
+    {#if details.hnScore}
+      <span class="hnBody__score">&blacktriangle;{details.hnScore}</span>
+    {/if}
+    <div class="hnBody__content">
+      <a href={details.url} class="hnBody__title" target="_blank" rel="noopener noreferrer">
+        {hnType} - {hnTitle}
+      </a>
+      {#if details.commentCount}
+        <div class="hnBody__comments">{details.commentCount} comments</div>
+      {/if}
+    </div>
+  </div>
+  {#if details.body}
+    <div class="hnBody__reply" class:hnBody__reply--visible={isComment}>
+      <span class="hnBody__replyArrow">&curarr;</span>
+      <div class="hnBody__text">{@html DOMPurify.sanitize(details.body)}</div>
+    </div>
+  {/if}
+</ActivityItem>
+
+<style>
+  .hnBody__row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .hnBody__content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .hnBody__title {
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--subtle);
+    text-decoration: none;
+  }
+
+  .hnBody__title:hover {
+    text-decoration: underline;
+  }
+
+  .hnBody__score {
+    background: var(--fg);
+    color: var(--bg);
+    padding: 0 0.3rem;
+    font-size: 0.85em;
+    flex-shrink: 0;
+    text-decoration: none;
+    display: inline-block;
+  }
+
+  .hnBody__comments {
+    color: var(--subtle);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+  }
+
+  .hnBody__reply {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .hnBody__replyArrow {
+    display: none;
+    color: var(--subtle);
+    font-size: 1rem;
+    line-height: 1.6;
+    flex-shrink: 0;
+  }
+
+  .hnBody__reply--visible .hnBody__replyArrow {
+    display: block;
+  }
+
+  .hnBody__reply--visible .hnBody__text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .hnBody__text {
+    line-height: 1.6;
+    color: var(--fg);
+    font-size: 0.9375rem;
+  }
+
+  .hnBody__text :global(p) {
+    margin: 0.5rem 0;
+  }
+
+  .hnBody__text :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  .hnBody__text :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .hnBody__text :global(a) {
+    color: var(--fg);
+    text-decoration: underline;
+  }
+
+  .hnBody__text :global(i) {
+    font-style: italic;
+  }
+
+  .hnBody__text :global(code) {
+    font-family: 'BerkeleyMono', monospace;
+    background: color-mix(in srgb, var(--fg) 10%, transparent);
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.9em;
+  }
+
+  .hnBody__text :global(pre) {
+    background: color-mix(in srgb, var(--fg) 10%, transparent);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    margin: 0.5rem 0;
+  }
+
+  .hnBody__text :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+</style>

--- a/src/lib/components/ActivityItem/ActivityItemPlex.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemPlex.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import type { SelectActivityPlex } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+  import PlexReviewForm from '$lib/components/PlexReviewForm/PlexReviewForm.svelte';
+  import StarRating from '$lib/components/StarRating/StarRating.svelte';
+
+  interface Props {
+    activityId: number;
+    details: SelectActivityPlex;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+    onUpdate: (rating: number | null, review: string | null) => void;
+  }
+
+  let { activityId, details, timestamp, isPrivate, isAdmin, onHide, onUpdate }: Props = $props();
+
+  let isEditing = $state(false);
+</script>
+
+<ActivityItem type="plex" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <div class="plexBody">
+    {#if details.thumbnailUrl}
+      {#if details.imdbUrl}
+        <a href={details.imdbUrl} target="_blank" rel="noopener noreferrer">
+          <img src={details.thumbnailUrl} alt="" class="plexBody__poster" />
+        </a>
+      {:else}
+        <img src={details.thumbnailUrl} alt="" class="plexBody__poster" />
+      {/if}
+    {/if}
+    <div class="plexBody__content">
+      <div class="plexBody__titleRow">
+        {#if details.imdbUrl}
+          <a href={details.imdbUrl} target="_blank" rel="noopener noreferrer" class="plexBody__title">
+            {details.title}{#if details.year}&nbsp;({details.year}){/if}
+          </a>
+        {:else}
+          <span class="plexBody__title">
+            {details.title}{#if details.year}&nbsp;({details.year}){/if}
+          </span>
+        {/if}
+        {#if details.director}
+          <span class="plexBody__director">by {details.director}</span>
+        {/if}
+      </div>
+      {#if !isEditing}
+        {#if details.rating}
+          <StarRating rating={details.rating} />
+        {/if}
+        {#if details.review}
+          <div class="plexBody__review">{details.review}</div>
+        {/if}
+      {/if}
+      {#if isAdmin}
+        <PlexReviewForm
+          {activityId}
+          currentRating={details.rating ?? null}
+          currentReview={details.review ?? null}
+          onEditingChange={(editing) => (isEditing = editing)}
+          onSave={(rating, review) => onUpdate(rating, review)}
+        />
+      {/if}
+    </div>
+  </div>
+</ActivityItem>
+
+<style>
+  .plexBody {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .plexBody__poster {
+    width: 6rem;
+    height: auto;
+    flex-shrink: 0;
+  }
+
+  .plexBody__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .plexBody__titleRow {
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+  }
+
+  .plexBody__title {
+    font-weight: 600;
+    line-height: 1.4;
+    text-decoration: none;
+  }
+
+  .plexBody__title:hover {
+    text-decoration: underline;
+  }
+
+  .plexBody__director {
+    color: var(--subtle);
+    font-size: 0.875rem;
+  }
+
+  .plexBody__review {
+    line-height: 1.6;
+    color: var(--fg);
+    font-size: 0.9375rem;
+    white-space: pre-line;
+  }
+
+  @media (max-width: 768px) {
+    .plexBody {
+      display: block;
+    }
+
+    .plexBody__poster {
+      float: left;
+      margin-right: 1rem;
+      margin-bottom: 0.5rem;
+      width: 5rem;
+    }
+
+    .plexBody__content {
+      display: block;
+    }
+  }
+</style>

--- a/src/lib/components/ActivityItem/ActivityItemReddit.svelte
+++ b/src/lib/components/ActivityItem/ActivityItemReddit.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import type { SelectActivityReddit } from '$db/schema';
+  import ActivityItem from './ActivityItem.svelte';
+
+  interface Props {
+    details: SelectActivityReddit;
+    timestamp: number;
+    isPrivate: boolean;
+    isAdmin: boolean;
+    onHide: () => void;
+  }
+
+  let { details, timestamp, isPrivate, isAdmin, onHide }: Props = $props();
+</script>
+
+<ActivityItem type="reddit" {timestamp} {isPrivate} {isAdmin} {onHide}>
+  <a
+    href="https://reddit.com/r/{details.subreddit}"
+    class="redditBody__subreddit"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    r/{details.subreddit}
+  </a>
+  <a href={details.url} class="redditBody__title" target="_blank" rel="noopener noreferrer">
+    {details.title}
+  </a>
+  {#if details.body}
+    <div class="redditBody__text">{details.body}</div>
+  {/if}
+</ActivityItem>
+
+<style>
+  .redditBody__subreddit {
+    display: block;
+    font-family: 'BerkeleyMono', monospace;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: lowercase;
+    letter-spacing: 0.05em;
+    color: var(--fg);
+    text-decoration: none;
+  }
+
+  .redditBody__subreddit:hover {
+    text-decoration: underline;
+  }
+
+  .redditBody__title {
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--subtle);
+    text-decoration: none;
+  }
+
+  .redditBody__title:hover {
+    text-decoration: underline;
+  }
+
+  .redditBody__text {
+    line-height: 1.6;
+    color: var(--fg);
+    font-size: 0.9375rem;
+    margin-top: 0.5rem;
+    white-space: pre-line;
+  }
+</style>

--- a/src/lib/components/ActivityItem/index.ts
+++ b/src/lib/components/ActivityItem/index.ts
@@ -1,0 +1,7 @@
+export { default as ActivityItem } from './ActivityItem.svelte';
+export { default as ActivityItemBgg } from './ActivityItemBgg.svelte';
+export { default as ActivityItemBluesky } from './ActivityItemBluesky.svelte';
+export { default as ActivityItemGithub } from './ActivityItemGithub.svelte';
+export { default as ActivityItemHackernews } from './ActivityItemHackernews.svelte';
+export { default as ActivityItemPlex } from './ActivityItemPlex.svelte';
+export { default as ActivityItemReddit } from './ActivityItemReddit.svelte';

--- a/src/routes/activity/+page.server.ts
+++ b/src/routes/activity/+page.server.ts
@@ -31,11 +31,7 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
   const endDate = url.searchParams.get('endDate');
 
   // Build conditions for the main query
-  const conditions = [eq(activityTable.isThreadRoot, true)];
-
-  if (!isAdmin) {
-    conditions.push(eq(activityTable.isPrivate, false));
-  }
+  const conditions = [eq(activityTable.isThreadRoot, true), eq(activityTable.isPrivate, false)];
 
   if (typeFilter) {
     conditions.push(eq(activityTable.type, typeFilter));
@@ -151,9 +147,6 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
     type: string;
     externalId: string;
     timestamp: number;
-    title: string;
-    url: string | null;
-    thumbnailUrl: string | null;
     isPrivate: boolean;
     createdAt: Date;
     details: unknown;

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -6,25 +6,23 @@
     SelectActivityHackernews,
     SelectActivityPlex,
     SelectActivityGithub,
+    SelectActivityBluesky,
+    SelectActivityReddit,
+    SelectActivityBgg,
     BlueskyThreadPost,
     SelectBlueskyAuthor
   } from '$db/schema';
-  import BlueskyThread from '$lib/components/BlueskyThread/BlueskyThread.svelte';
+  import {
+    ActivityItemPlex,
+    ActivityItemGithub,
+    ActivityItemBluesky,
+    ActivityItemHackernews,
+    ActivityItemReddit,
+    ActivityItemBgg
+  } from '$lib/components/ActivityItem';
   import Button from '$lib/components/Button/Button.svelte';
-  import PlexReviewForm from '$lib/components/PlexReviewForm/PlexReviewForm.svelte';
-  import StarRating from '$lib/components/StarRating/StarRating.svelte';
-  import { mode } from 'mode-watcher';
-  import { marked } from 'marked';
-  import DOMPurify from 'isomorphic-dompurify';
   import Loader from '$lib/components/StlViewer/Loader.svelte';
-
-  // Configure marked to wrap images in links
-  const renderer = new marked.Renderer();
-  renderer.image = ({ href, title, text }) => {
-    const titleAttr = title ? ` title="${title}"` : '';
-    return `<a href="${href}" target="_blank" rel="noopener noreferrer"><img src="${href}" alt="${text}"${titleAttr}></a>`;
-  };
-  marked.use({ renderer });
+  import { mode } from 'mode-watcher';
 
   let { data }: { data: PageData } = $props();
 
@@ -33,9 +31,6 @@
     type: string;
     externalId: string;
     timestamp: number;
-    title: string;
-    url: string | null;
-    thumbnailUrl: string | null;
     isPrivate: boolean;
     createdAt: Date;
     details: unknown;
@@ -55,12 +50,8 @@
   let page = $state(1);
   let isLoading = $state(false);
   let hasMore = $state(data.activities.length === 20);
-  let editingPlexId = $state<number | null>(null);
 
-  // Default to white (dark mode) since that's the default theme
   let iconColor = $derived(mode.current === 'light' ? 'black' : 'white');
-
-  // Convert blueskyAuthors object to a Map for the component
   let authorsMap = $derived(new Map(Object.entries(blueskyAuthors)));
 
   function buildFetchUrl(pageNum: number) {
@@ -82,12 +73,10 @@
       const result = await response.json();
 
       if (result.activities && result.activities.length > 0) {
-        // Merge activities, avoiding duplicates
         const existingIds = new Set(activities.map((a) => a.id));
         const newActivities = result.activities.filter((a: ActivityWithDetails) => !existingIds.has(a.id));
         activities = [...activities, ...newActivities];
 
-        // Merge bluesky authors
         if (result.blueskyAuthors) {
           blueskyAuthors = { ...blueskyAuthors, ...result.blueskyAuthors };
         }
@@ -140,28 +129,6 @@
     }, 100);
   }
 
-  function formatTimestamp(timestamp: number): string {
-    const date = new Date(timestamp * 1000);
-    const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    const seconds = Math.floor(diff / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-
-    if (days > 7) {
-      return date.toLocaleDateString();
-    } else if (days > 0) {
-      return `${days}d ago`;
-    } else if (hours > 0) {
-      return `${hours}h ago`;
-    } else if (minutes > 0) {
-      return `${minutes}m ago`;
-    } else {
-      return 'just now';
-    }
-  }
-
   function getTypeIcon(type: string, color: string): string {
     const base = 'https://cdn.simpleicons.org';
     switch (type) {
@@ -193,13 +160,14 @@
     }
   }
 
-  async function deleteActivity(id: number, title: string) {
-    if (!confirm(`Delete "${title}"?`)) return;
+  function hideActivity(id: number, title: string | null | undefined) {
+    if (!confirm(`Hide "${title || 'this item'}"?`)) return;
 
-    const response = await fetch(`/api/activity/${id}`, { method: 'DELETE' });
-    if (response.ok) {
-      activities = activities.filter((a) => a.id !== id);
-    }
+    fetch(`/api/activity/${id}`, { method: 'DELETE' }).then((response) => {
+      if (response.ok) {
+        activities = activities.filter((a) => a.id !== id);
+      }
+    });
   }
 
   onMount(() => {
@@ -235,7 +203,7 @@
     {#if filterPopoverIsOpen}
       <div class="activity__filterPopover">
         <input type="date" bind:value={startDate} onchange={applyFilters} />
-        <span class="activity__filterArrow">→</span>
+        <span class="activity__filterArrow">&rarr;</span>
         <input type="date" bind:value={endDate} onchange={applyFilters} />
 
         <select bind:value={sortOrder} onchange={applyFilters}>
@@ -259,198 +227,70 @@
   {:else}
     <div class="activity__list">
       {#each activities as activity (activity.id)}
-        {#if activity.type === 'bluesky'}
-          {@const thread = (activity.thread || []) as BlueskyThreadPost[]}
-          <div class="activityItem activityItem--bluesky">
-            <div class="activityItem__header">
-              <img src={getTypeIcon(activity.type, iconColor)} alt="" class="activityItem__icon" />
-              <span class="activityItem__type">bluesky</span>
-              <span class="activityItem__time">{formatTimestamp(activity.timestamp)}</span>
-              {#if activity.isPrivate && data.isAdmin}
-                <span class="activityItem__private">🔒</span>
-              {/if}
-              {#if data.isAdmin}
-                <button class="activityItem__delete" onclick={() => deleteActivity(activity.id, activity.title)}>
-                  ×
-                </button>
-              {/if}
-            </div>
-            <BlueskyThread {thread} authors={authorsMap} currentUri={activity.externalId} />
-          </div>
-        {:else if activity.type === 'plex'}
-          {@const plexDetails = activity.details as SelectActivityPlex | null}
-          <div class="activityItem activityItem--plex">
-            <div class="activityItem__header">
-              <img src={getTypeIcon(activity.type, iconColor)} alt="" class="activityItem__icon" />
-              <span class="activityItem__type">Plex</span>
-              <span class="activityItem__time">{formatTimestamp(activity.timestamp)}</span>
-              {#if activity.isPrivate && data.isAdmin}
-                <span class="activityItem__private">🔒</span>
-              {/if}
-              {#if data.isAdmin}
-                <button class="activityItem__delete" onclick={() => deleteActivity(activity.id, activity.title)}>
-                  ×
-                </button>
-              {/if}
-            </div>
-            <div class="activityItem__body">
-              {#if activity.thumbnailUrl}
-                {#if plexDetails?.imdbUrl}
-                  <a href={plexDetails.imdbUrl} target="_blank" rel="noopener noreferrer">
-                    <img src={activity.thumbnailUrl} alt="" class="activityItem__plexPoster" />
-                  </a>
-                {:else}
-                  <img src={activity.thumbnailUrl} alt="" class="activityItem__plexPoster" />
-                {/if}
-              {/if}
-              <div class="activityItem__plexContent">
-                <div class="activityItem__plexTitleRow">
-                  {#if plexDetails?.imdbUrl}
-                    <a href={plexDetails.imdbUrl} target="_blank" rel="noopener noreferrer" class="activityItem__title">
-                      {activity.title}{#if plexDetails?.year}{' '}({plexDetails.year}){/if}
-                    </a>
-                  {:else}
-                    <span class="activityItem__title">
-                      {activity.title}{#if plexDetails?.year}{' '}({plexDetails.year}){/if}
-                    </span>
-                  {/if}
-                  {#if plexDetails?.director}
-                    <span class="activityItem__plexDirector">by {plexDetails.director}</span>
-                  {/if}
-                </div>
-                {#if editingPlexId !== activity.id}
-                  {#if plexDetails?.rating}
-                    <StarRating rating={plexDetails.rating} />
-                  {/if}
-                  {#if plexDetails?.review}
-                    <div class="activityItem__plexReview">{plexDetails.review}</div>
-                  {/if}
-                {/if}
-                {#if data.isAdmin}
-                  <PlexReviewForm
-                    activityId={activity.id}
-                    currentRating={plexDetails?.rating ?? null}
-                    currentReview={plexDetails?.review ?? null}
-                    onEditingChange={(editing) => (editingPlexId = editing ? activity.id : null)}
-                    onSave={(rating, review) => {
-                      const idx = activities.findIndex((a) => a.id === activity.id);
-                      if (idx !== -1 && activities[idx].details) {
-                        (activities[idx].details as SelectActivityPlex).rating = rating;
-                        (activities[idx].details as SelectActivityPlex).review = review;
-                      }
-                    }}
-                  />
-                {/if}
-              </div>
-            </div>
-          </div>
-        {:else if activity.type === 'hackernews'}
-          {@const hnDetails = activity.details as SelectActivityHackernews | null}
-          {@const hnTypeMap = { story: 'Post', comment: 'Comment', ask: 'Ask HN', show: 'Show HN' }}
-          {@const hnType = hnDetails?.itemType ? hnTypeMap[hnDetails.itemType] || 'Post' : 'Post'}
-          {@const hnTitle = activity.title.replace(/^Comment on:\s*/i, '')}
-          {@const isHnComment = hnDetails?.itemType === 'comment'}
-          <div class="activityItem activityItem--hackernews">
-            <div class="activityItem__header">
-              <img src={getTypeIcon(activity.type, iconColor)} alt="" class="activityItem__icon" />
-              <span class="activityItem__type">Hacker News</span>
-              <span class="activityItem__time">{formatTimestamp(activity.timestamp)}</span>
-              {#if activity.isPrivate && data.isAdmin}
-                <span class="activityItem__private">🔒</span>
-              {/if}
-              {#if data.isAdmin}
-                <button class="activityItem__delete" onclick={() => deleteActivity(activity.id, activity.title)}>
-                  ×
-                </button>
-              {/if}
-            </div>
-            <div class="activityItem__body">
-              <div class="activityItem__hnRow">
-                {#if hnDetails?.hnScore}<span class="activityItem__hnScore">▲{hnDetails.hnScore}</span>{/if}
-                <div class="activityItem__hnContent">
-                  <a href={activity.url} class="activityItem__hnTitle" target="_blank" rel="noopener noreferrer">
-                    {hnType} - {hnTitle}
-                  </a>
-                  {#if hnDetails?.commentCount}
-                    <div class="activityItem__hnComments">{hnDetails.commentCount} comments</div>
-                  {/if}
-                </div>
-              </div>
-              {#if hnDetails?.body}
-                <div class="activityItem__reply" class:activityItem__reply--visible={isHnComment}>
-                  <span class="activityItem__replyArrow">⤷</span>
-                  <div class="activityItem__hnBody">{@html DOMPurify.sanitize(hnDetails.body)}</div>
-                </div>
-              {/if}
-            </div>
-          </div>
+        {#if activity.type === 'plex'}
+          {@const details = activity.details as SelectActivityPlex}
+          <ActivityItemPlex
+            activityId={activity.id}
+            {details}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+            onUpdate={(rating, review) => {
+              if (details) {
+                details.rating = rating;
+                details.review = review;
+              }
+            }}
+          />
         {:else if activity.type === 'github'}
-          {@const ghDetails = activity.details as SelectActivityGithub | null}
-          {@const isGhComment = ghDetails?.eventType === 'issue_comment'}
-          <div class="activityItem activityItem--github">
-            <div class="activityItem__header">
-              <img src={getTypeIcon(activity.type, iconColor)} alt="" class="activityItem__icon" />
-              <span class="activityItem__type">GitHub</span>
-              <span class="activityItem__time">{formatTimestamp(activity.timestamp)}</span>
-              {#if activity.isPrivate && data.isAdmin}
-                <span class="activityItem__private">🔒</span>
-              {/if}
-              {#if data.isAdmin}
-                <button class="activityItem__delete" onclick={() => deleteActivity(activity.id, activity.title)}>
-                  ×
-                </button>
-              {/if}
-            </div>
-            <div class="activityItem__body">
-              <a
-                href="https://github.com/{ghDetails?.repo}"
-                class="activityItem__repo"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {ghDetails?.repo || 'github'}
-              </a>
-              <a href={activity.url} class="activityItem__githubTitle" target="_blank" rel="noopener noreferrer">
-                {activity.title}
-              </a>
-              {#if ghDetails?.commitMessage && (ghDetails.eventType === 'issue_comment' || ghDetails.eventType === 'pr_opened')}
-                <div class="activityItem__reply" class:activityItem__reply--visible={isGhComment}>
-                  <span class="activityItem__replyArrow">⤷</span>
-                  <div class="activityItem__githubMessage">
-                    {@html DOMPurify.sanitize(marked(ghDetails.commitMessage) as string)}
-                  </div>
-                </div>
-              {/if}
-            </div>
-          </div>
-        {:else}
-          <a href="/activity/{activity.id}" class="activityItem">
-            <div class="activityItem__header">
-              <img src={getTypeIcon(activity.type, iconColor)} alt="" class="activityItem__icon" />
-              <span class="activityItem__type">{activity.type}</span>
-              <span class="activityItem__time">{formatTimestamp(activity.timestamp)}</span>
-              {#if activity.isPrivate && data.isAdmin}
-                <span class="activityItem__private">🔒</span>
-              {/if}
-              {#if data.isAdmin}
-                <button
-                  class="activityItem__delete"
-                  onclick={(e) => {
-                    e.preventDefault();
-                    deleteActivity(activity.id, activity.title);
-                  }}
-                >
-                  ×
-                </button>
-              {/if}
-            </div>
-            <div class="activityItem__body">
-              <div class="activityItem__title">{activity.title}</div>
-              {#if activity.thumbnailUrl}
-                <img src={activity.thumbnailUrl} alt="" class="activityItem__thumbnail" />
-              {/if}
-            </div>
-          </a>
+          {@const details = activity.details as SelectActivityGithub}
+          <ActivityItemGithub
+            {details}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+          />
+        {:else if activity.type === 'bluesky'}
+          {@const details = activity.details as SelectActivityBluesky}
+          {@const thread = (activity.thread || []) as BlueskyThreadPost[]}
+          <ActivityItemBluesky
+            externalId={activity.externalId}
+            {thread}
+            authors={authorsMap}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+          />
+        {:else if activity.type === 'hackernews'}
+          {@const details = activity.details as SelectActivityHackernews}
+          <ActivityItemHackernews
+            {details}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+          />
+        {:else if activity.type === 'reddit'}
+          {@const details = activity.details as SelectActivityReddit}
+          <ActivityItemReddit
+            {details}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+          />
+        {:else if activity.type === 'bgg'}
+          {@const details = activity.details as SelectActivityBgg}
+          <ActivityItemBgg
+            {details}
+            timestamp={activity.timestamp}
+            isPrivate={activity.isPrivate}
+            isAdmin={data.isAdmin}
+            onHide={() => hideActivity(activity.id, details?.title)}
+          />
         {/if}
       {/each}
     </div>
@@ -533,318 +373,6 @@
     gap: 1rem;
   }
 
-  .activityItem {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    text-decoration: none;
-    color: inherit;
-  }
-
-  .activityItem__header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 0.875rem;
-    color: var(--subtle);
-  }
-
-  .activityItem__header .activityItem__icon {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  .activityItem__type {
-    text-transform: capitalize;
-  }
-
-  .activityItem__time {
-    color: var(--subtle);
-  }
-
-  .activityItem__private {
-    font-size: 0.75rem;
-  }
-
-  .activityItem__delete {
-    opacity: 0;
-    background: none;
-    border: none;
-    color: var(--subtle);
-    font-size: 1rem;
-    cursor: pointer;
-    padding: 0 0.25rem;
-    line-height: 1;
-    transition: opacity 0.15s;
-  }
-
-  .activityItem__delete:hover {
-    color: red;
-  }
-
-  .activityItem:hover .activityItem__delete {
-    opacity: 1;
-  }
-
-  .activityItem__body {
-    margin-left: 1.75rem;
-  }
-
-  .activityItem__reply {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-  }
-
-  .activityItem__replyArrow {
-    display: none;
-    color: var(--subtle);
-    font-size: 1rem;
-    line-height: 1.6;
-    flex-shrink: 0;
-  }
-
-  .activityItem__reply--visible .activityItem__replyArrow {
-    display: block;
-  }
-
-  .activityItem__reply--visible .activityItem__hnBody,
-  .activityItem__reply--visible .activityItem__githubMessage {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .activityItem__title {
-    font-weight: 600;
-    line-height: 1.4;
-  }
-
-  .activityItem--bluesky :global(.thread) {
-    margin-left: 1rem;
-  }
-
-  .activityItem--github {
-    margin-bottom: 1rem;
-  }
-
-  .activityItem__repo {
-    display: block;
-    font-family: 'BerkeleyMono', monospace;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--fg);
-    text-decoration: none;
-  }
-
-  .activityItem__repo:hover {
-    text-decoration: underline;
-  }
-
-  .activityItem__githubTitle {
-    font-weight: 600;
-    line-height: 1.4;
-    color: var(--subtle);
-    text-decoration: none;
-  }
-
-  .activityItem__githubTitle:hover {
-    text-decoration: underline;
-  }
-
-  .activityItem__githubMessage {
-    line-height: 1.6;
-  }
-
-  .activityItem__githubMessage :global(p) {
-    margin: 0.5rem 0;
-  }
-
-  .activityItem__githubMessage :global(p:first-child) {
-    margin-top: 0;
-  }
-
-  .activityItem__githubMessage :global(p:last-child) {
-    margin-bottom: 0;
-  }
-
-  .activityItem__githubMessage :global(a) {
-    color: var(--fg);
-    text-decoration: underline;
-  }
-
-  .activityItem__githubMessage :global(code) {
-    font-family: 'BerkeleyMono', monospace;
-    background: color-mix(in srgb, var(--fg) 10%, transparent);
-    padding: 0.1rem 0.3rem;
-    border-radius: 0.25rem;
-    font-size: 0.9em;
-  }
-
-  .activityItem__githubMessage :global(pre) {
-    background: color-mix(in srgb, var(--fg) 10%, transparent);
-    padding: 1rem;
-    border-radius: 0.5rem;
-    overflow-x: auto;
-    margin: 0.5rem 0;
-  }
-
-  .activityItem__githubMessage :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-
-  .activityItem__githubMessage :global(img) {
-    max-width: 100%;
-    height: auto;
-  }
-
-  .activityItem--plex .activityItem__body {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-
-  .activityItem__plexPoster {
-    width: 6rem;
-    height: auto;
-    flex-shrink: 0;
-  }
-
-  .activityItem__plexContent {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .activityItem__plexTitleRow {
-    display: flex;
-    align-items: baseline;
-    gap: 0.25rem;
-    flex-wrap: wrap;
-  }
-
-  .activityItem__plexTitleRow .activityItem__title {
-    text-decoration: none;
-  }
-
-  .activityItem__plexTitleRow .activityItem__title:hover {
-    text-decoration: underline;
-  }
-
-  .activityItem__plexDirector {
-    color: var(--subtle);
-    font-size: 0.875rem;
-  }
-
-  .activityItem__plexReview {
-    line-height: 1.6;
-    color: var(--fg);
-    font-size: 0.9375rem;
-    white-space: pre-line;
-  }
-
-  .activityItem--hackernews {
-    margin-bottom: 1rem;
-  }
-
-  .activityItem__hnRow {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .activityItem__hnContent {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .activityItem__hnTitle {
-    font-weight: 600;
-    line-height: 1.4;
-    color: var(--subtle);
-    text-decoration: none;
-  }
-
-  .activityItem__hnTitle:hover {
-    text-decoration: underline;
-  }
-
-  .activityItem__hnScore {
-    background: var(--fg);
-    color: var(--bg);
-    padding: 0 0.3rem;
-    font-size: 0.85em;
-    flex-shrink: 0;
-    text-decoration: none;
-    display: inline-block;
-  }
-
-  .activityItem__hnComments {
-    color: var(--subtle);
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-  }
-
-  .activityItem__hnBody {
-    line-height: 1.6;
-    color: var(--fg);
-    font-size: 0.9375rem;
-  }
-
-  .activityItem__hnBody :global(p) {
-    margin: 0.5rem 0;
-  }
-
-  .activityItem__hnBody :global(p:first-child) {
-    margin-top: 0;
-  }
-
-  .activityItem__hnBody :global(p:last-child) {
-    margin-bottom: 0;
-  }
-
-  .activityItem__hnBody :global(a) {
-    color: var(--fg);
-    text-decoration: underline;
-  }
-
-  .activityItem__hnBody :global(i) {
-    font-style: italic;
-  }
-
-  .activityItem__hnBody :global(code) {
-    font-family: 'BerkeleyMono', monospace;
-    background: color-mix(in srgb, var(--fg) 10%, transparent);
-    padding: 0.1rem 0.3rem;
-    border-radius: 0.25rem;
-    font-size: 0.9em;
-  }
-
-  .activityItem__hnBody :global(pre) {
-    background: color-mix(in srgb, var(--fg) 10%, transparent);
-    padding: 1rem;
-    border-radius: 0.5rem;
-    overflow-x: auto;
-    margin: 0.5rem 0;
-  }
-
-  .activityItem__hnBody :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-
-  .activityItem__thumbnail {
-    width: 4rem;
-    height: 4rem;
-    object-fit: cover;
-    border-radius: 0.25rem;
-    flex-shrink: 0;
-  }
-
   .activity__allLoaded {
     animation: fadein 0.5s;
     animation-iteration-count: 1;
@@ -922,25 +450,6 @@
 
     .activity__filterArrow {
       display: none;
-    }
-
-    .activityItem--plex .activityItem__body {
-      display: block;
-    }
-
-    .activityItem__plexPoster {
-      float: left;
-      margin-right: 1rem;
-      margin-bottom: 0.5rem;
-      width: 5rem;
-    }
-
-    .activityItem__plexContent {
-      display: block;
-    }
-
-    .activityItem__plexReview {
-      clear: none;
     }
   }
 </style>

--- a/src/routes/api/activity/[id]/+server.ts
+++ b/src/routes/api/activity/[id]/+server.ts
@@ -1,0 +1,41 @@
+import { activityTable } from '$db/schema';
+import { checkAuth } from '$lib/server/auth';
+import { db } from '$lib/server/db';
+import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import type { RequestHandler } from './$types';
+
+// Hide activity by setting isPrivate to true
+export const DELETE: RequestHandler = async ({ params, cookies }) => {
+  const isAdmin = checkAuth(cookies);
+
+  if (!isAdmin) {
+    throw error(401, 'Unauthorized');
+  }
+
+  const id = parseInt(params.id);
+  if (isNaN(id)) {
+    throw error(400, 'Invalid ID');
+  }
+
+  try {
+    const activity = await db.select().from(activityTable).where(eq(activityTable.id, id)).get();
+
+    if (!activity) {
+      throw error(404, 'Activity not found');
+    }
+
+    // Mark as private instead of deleting - prevents re-ingestion
+    await db.update(activityTable).set({ isPrivate: true }).where(eq(activityTable.id, id));
+
+    return json({ success: true, hidden: id });
+  } catch (err) {
+    if (err && typeof err === 'object' && 'status' in err) {
+      throw err;
+    }
+    return json(
+      { message: 'Internal Server Error', error: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+};

--- a/src/routes/api/activity/ingest/bgg/+server.ts
+++ b/src/routes/api/activity/ingest/bgg/+server.ts
@@ -102,9 +102,6 @@ export const POST: RequestHandler = async ({ request }) => {
             type: 'bgg',
             externalId: item.externalId,
             timestamp: item.timestamp,
-            title: item.title,
-            url: item.url,
-            thumbnailUrl: item.thumbnailUrl || null,
             isPrivate: false,
             isThreadRoot: true,
             threadLatestTimestamp: item.timestamp
@@ -114,6 +111,8 @@ export const POST: RequestHandler = async ({ request }) => {
         // Create the BGG-specific record
         await db.insert(activityBggTable).values({
           activityId: activity.id,
+          title: item.title,
+          thumbnailUrl: item.thumbnailUrl || null,
           gameId: item.gameId,
           playDate: item.playDate,
           location: item.location || null,

--- a/src/routes/api/activity/ingest/bluesky/+server.ts
+++ b/src/routes/api/activity/ingest/bluesky/+server.ts
@@ -371,9 +371,6 @@ export const POST: RequestHandler = async ({ request }) => {
             type: 'bluesky',
             externalId: item.externalId,
             timestamp: item.timestamp,
-            title: item.title,
-            url: item.url,
-            thumbnailUrl: null,
             isPrivate: false,
             isThreadRoot: effectiveIsRoot,
             threadLatestTimestamp: effectiveIsRoot ? item.timestamp : null
@@ -383,6 +380,7 @@ export const POST: RequestHandler = async ({ request }) => {
         // Create the Bluesky-specific record
         await db.insert(activityBlueskyTable).values({
           activityId: activity.id,
+          title: item.title,
           authorDid: item.authorDid,
           postText: item.postText,
           isReply: item.isReply,

--- a/src/routes/api/activity/ingest/github/+server.ts
+++ b/src/routes/api/activity/ingest/github/+server.ts
@@ -79,9 +79,6 @@ export const POST: RequestHandler = async ({ request }) => {
             type: 'github',
             externalId: item.externalId,
             timestamp: item.timestamp,
-            title: item.title,
-            url: item.url,
-            thumbnailUrl: null,
             isPrivate: false,
             isThreadRoot: true,
             threadLatestTimestamp: item.timestamp
@@ -91,6 +88,8 @@ export const POST: RequestHandler = async ({ request }) => {
         // Create the GitHub-specific record
         await db.insert(activityGithubTable).values({
           activityId: activity.id,
+          title: item.title,
+          url: item.url,
           eventType: item.eventType,
           repo: item.repo,
           ref: item.ref || null,

--- a/src/routes/api/activity/ingest/hackernews/+server.ts
+++ b/src/routes/api/activity/ingest/hackernews/+server.ts
@@ -103,9 +103,6 @@ export const POST: RequestHandler = async ({ request }) => {
             type: 'hackernews',
             externalId: item.externalId,
             timestamp: item.timestamp,
-            title: item.title,
-            url: item.url,
-            thumbnailUrl: null,
             isPrivate: false,
             isThreadRoot: true,
             threadLatestTimestamp: item.timestamp
@@ -115,6 +112,8 @@ export const POST: RequestHandler = async ({ request }) => {
         // Create the Hackernews-specific record
         await db.insert(activityHackernewsTable).values({
           activityId: activity.id,
+          title: item.title,
+          url: item.url,
           itemType: item.itemType,
           body: item.body || null,
           hnScore: item.hnScore ?? null,

--- a/src/routes/api/activity/ingest/reddit/+server.ts
+++ b/src/routes/api/activity/ingest/reddit/+server.ts
@@ -107,9 +107,6 @@ export const POST: RequestHandler = async ({ request }) => {
             type: 'reddit',
             externalId: item.externalId,
             timestamp: item.timestamp,
-            title: item.title,
-            url: item.url,
-            thumbnailUrl: null,
             isPrivate: false,
             isThreadRoot: true,
             threadLatestTimestamp: item.timestamp
@@ -119,6 +116,8 @@ export const POST: RequestHandler = async ({ request }) => {
         // Create the Reddit-specific record
         await db.insert(activityRedditTable).values({
           activityId: activity.id,
+          title: item.title,
+          url: item.url,
           subreddit: item.subreddit,
           itemType: item.itemType,
           body: item.body || null,

--- a/src/routes/api/activity/list/+server.ts
+++ b/src/routes/api/activity/list/+server.ts
@@ -12,7 +12,6 @@ import {
   type BlueskyThreadPost,
   type SelectBlueskyAuthor
 } from '$db/schema';
-import { checkAuth } from '$lib/server/auth';
 import { db } from '$lib/server/db';
 import { json } from '@sveltejs/kit';
 import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
@@ -22,8 +21,7 @@ function isValidActivityType(type: string): type is ActivityType {
   return VALID_ACTIVITY_TYPES.includes(type as ActivityType);
 }
 
-export const GET: RequestHandler = async ({ url, cookies }) => {
-  const isAdmin = checkAuth(cookies);
+export const GET: RequestHandler = async ({ url }) => {
   const page = parseInt(url.searchParams.get('page') || '1');
   const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 100);
   const typeFilterParam = url.searchParams.get('type');
@@ -35,11 +33,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
   const offset = (page - 1) * limit;
 
   // Build conditions for the main query
-  const conditions = [eq(activityTable.isThreadRoot, true)];
-
-  if (!isAdmin) {
-    conditions.push(eq(activityTable.isPrivate, false));
-  }
+  const conditions = [eq(activityTable.isThreadRoot, true), eq(activityTable.isPrivate, false)];
 
   if (typeFilter) {
     conditions.push(eq(activityTable.type, typeFilter));
@@ -159,9 +153,6 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       type: string;
       externalId: string;
       timestamp: number;
-      title: string;
-      url: string | null;
-      thumbnailUrl: string | null;
       isPrivate: boolean;
       createdAt: Date;
       details: unknown;

--- a/src/routes/api/activity/webhook/plex/+server.ts
+++ b/src/routes/api/activity/webhook/plex/+server.ts
@@ -199,9 +199,6 @@ export const POST: RequestHandler = async ({ url, request }) => {
         type: 'plex',
         externalId,
         timestamp: Math.floor(Date.now() / 1000),
-        title: metadata.title,
-        url: imdbUrl,
-        thumbnailUrl,
         isPrivate: false
       })
       .returning();
@@ -209,6 +206,8 @@ export const POST: RequestHandler = async ({ url, request }) => {
     // Create the Plex-specific record
     await db.insert(activityPlexTable).values({
       activityId: activity.id,
+      title: metadata.title,
+      thumbnailUrl,
       mediaType,
       imdbId,
       imdbUrl,


### PR DESCRIPTION
The activity schema was a little messy. Half the data was in the main activity table, and the other half was in the specific providers activity. This made it awkard for the movie reviews because the title is in one place, and the body another. It also forced the components to do waaaay too much if/else checking.

The tables are now more readable, and new components were made for each activity type.

I also added proper abilities to hide activity in the rare cases where I don't want something in the feed. It's all public data, so this should be rare.